### PR TITLE
Adds loop support to Video

### DIFF
--- a/React360/js/Compositor/Video/BrowserVideoPlayer.js
+++ b/React360/js/Compositor/Video/BrowserVideoPlayer.js
@@ -127,7 +127,7 @@ export default class BrowserVideoPlayer implements VideoPlayer {
   }
 
   setLoop(loop: boolean) {
-    this._element.loop = true;
+    this._element.loop = loop ? true : null;
   }
 
   play() {

--- a/React360/js/Compositor/Video/Types.js
+++ b/React360/js/Compositor/Video/Types.js
@@ -43,6 +43,7 @@ export type VideoPlayOptions = {
   rotation?: VideoRotation,
   stereo?: VideoStereoFormat,
   volume?: number,
+  loop?:  boolean,
 };
 
 export type VideoOptions = VideoPlayOptions & {

--- a/React360/js/Modules/VideoModule.js
+++ b/React360/js/Modules/VideoModule.js
@@ -36,6 +36,9 @@ export default class VideoModule extends Module {
     if (params.volume !== undefined) {
       player.setVolume(params.volume);
     }
+    if (params.loop !==  undefined) {
+      player.setLoop(params.loop);
+    }
   }
 
   createPlayer(handle: string) {


### PR DESCRIPTION
## Motivation (required)

Adds the actual support for looping a video. The code is already in there but not accessible from the outside. I added the ability to use it from the outside through either the `setLoop` method or via the `VideoOption`'s added `loop` key.

## Test Plan (required)

Tested through my own repo using a simple play command, e.g.

```
        VideoModule.play('myplayer', {
          loop: true,
          source: {url: '/static_assets/video.mp4'}, // provide the path to the video
        });
```

