### PR TITLE
fix metro blacklist module path

### DIFF
--- a/packages/react-360-cli/generators/rn-cli.config.generator.js
+++ b/packages/react-360-cli/generators/rn-cli.config.generator.js
@@ -12,7 +12,7 @@ module.exports = config => ({
   contents: `'use strict';
 
 var path = require('path');
-var blacklist = require('metro-bundler/src/blacklist');
+var blacklist = require('metro/src/blacklist');
 
 var config = {
   getProjectRoots() {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

What existing problem does the pull request solve?

- "metro-bundler" has been renamed to "metro." When using the react-360-cli to spin up a project, npm start inevitably fails because the it is looking for a metro-bundler module that doesn't exist.

## Test Plan (required)

running `npm start` before changes:
<img width="449" alt="screen shot 2018-05-30 at 9 41 52 am" src="https://user-images.githubusercontent.com/26509901/40797070-2ca3e83e-64c4-11e8-8bde-6877a79a3a51.png">

running npm start after changes:
<img width="556" alt="screen shot 2018-05-31 at 11 15 41 am" src="https://user-images.githubusercontent.com/26509901/40797118-5074311a-64c4-11e8-9190-4eb9054c08bf.png">

