### PR TITLE
Fix example for changing environment background

### DIFF
--- a/docs/photos-and-videos.md
+++ b/docs/photos-and-videos.md
@@ -62,7 +62,7 @@ If your background is dynamic, such as in a multi-room environment, you'll want 
 import {Environment} from 'react-360';
 
 // Set the background to a 360 or 180 image
-Environment.setBackground(
+Environment.setBackgroundImage(
   asset('path/to/image.jpg'),
   {format: '2D'}, /* one of the formats mentioned above */
 );


### PR DESCRIPTION
Change Environment.setBackground to Environment.setBackgroundImage

## Motivation (required)

The example from the documentation was incorrect. There is no such method as "Environment.setBackground"
