### PR TITLE
Adding option to automatically copy static_assets to build folder when bundling

### DIFF
--- a/packages/react-360-cli/generators/package.json.generator.js
+++ b/packages/react-360-cli/generators/package.json.generator.js
@@ -18,6 +18,7 @@ module.exports = config => ({
   "scripts": {
     "start": "node node_modules/react-360/scripts/packager.js",
     "bundle": "node node_modules/react-360/scripts/bundle.js",
+    "build": "node node_modules/react-360/scripts/bundle.js && node node_modules/react-360/scripts/copy-assets.js",
     "open": "node -e \\"require('xopen')('http://localhost:8081/index.html')\\"",
     "devtools": "react-devtools",
     "test": "jest"

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+function copyFileSync( source, target ) {
+  var targetFile = target;
+  //if target is a directory a new file with the same name will be created
+  if ( fs.existsSync( target ) ) {
+    if ( fs.lstatSync( target ).isDirectory() ) {
+      targetFile = path.join( target, path.basename( source ) );
+    }
+  }
+  fs.writeFileSync(targetFile, fs.readFileSync(source));
+}
+
+function copyFolderRecursiveSync( source, target ) {
+  var files = [];
+  //check if folder needs to be created or integrated
+  var targetFolder = path.join( target, path.basename( source ) );
+  if ( !fs.existsSync( targetFolder ) ) {
+    fs.mkdirSync( targetFolder );
+  }
+  //copy
+  if ( fs.lstatSync( source ).isDirectory() ) {
+    files = fs.readdirSync( source );
+    files.forEach( function ( file ) {
+      var curSource = path.join( source, file );
+      if ( fs.lstatSync( curSource ).isDirectory() ) {
+        copyFolderRecursiveSync( curSource, targetFolder );
+      } else {
+        copyFileSync( curSource, targetFolder );
+      }
+    } );
+  }
+}
+
+function hasPackage(dir) {
+  const packagePath = path.join(dir, 'package.json');
+  try {
+    fs.statSync(packagePath);
+  } catch (e) {
+    return false;
+  }
+  const pkg = require(packagePath);
+  if (pkg && pkg.dependencies && pkg.dependencies['react-360']) {
+    return true;
+  }
+  return false;
+}
+
+function findProjectDir(dir) {
+  while (!hasPackage(dir)) {
+    const next = path.join(dir, '..');
+    if (dir === next) {
+      console.log('Could not find a React 360 project directory');
+      process.exit(1);
+    }
+    dir = path.join(dir, '..');
+  }
+  return dir;
+}
+
+const projectDir = process.env.PROJECT_LOCATION || findProjectDir(process.cwd());
+const staticAssetsDir = path.join(projectDir, 'static_assets');
+const buildDir = path.join(projectDir, 'build');
+
+copyFolderRecursiveSync(staticAssetsDir, buildDir)


### PR DESCRIPTION
Hi there,

I recently wanted to test react-360. I created simple project, bundled it and hosted it on server. I noticed that files from static_assets were not there. I went do docs and discovered that I have to put them on server manually :/

I don't mind it but I decided to help myself out and automate this process.

My conclusion was:
"Copying static_assets folder to build folder manually can be confusing for many people (at least I think so).
"

I created new script called copy_assets.js that will take all your files from static_assets folder and put them to build folder automatically.

I also added script called "build" in package.json  that takes care of bundling and copying all assets.

This way you don't need to remember each time to update your assets when your site goes life 🎉 

I hope it will be useful for someone :)

Happy coding 👍 
