### PR TITLE
Correct documentation references to addListener and staticAssetURL

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -34,7 +34,7 @@ Sets the current background to a video, referenced by the specified handle. The 
 VideoModule.createPlayer('myplayer');
 // Play a specific video
 VideoModule.play('myplayer', {
-  source: {url: staticResourceURL('path/to/video.mp4')}, // provide the path to the video
+  source: {url: staticAssetURL('path/to/video.mp4')}, // provide the path to the video
   stereo: '3DTB', // optionally, supply the format of the video
 });
 // Display the video on the Environment

--- a/docs/photos-and-videos.md
+++ b/docs/photos-and-videos.md
@@ -141,13 +141,13 @@ r360.compositor.setScreen(
 To create a Video Player from the React side, use the `VideoModule` Module. Again, a Player must be set up before it can be set to the Environment. Once it has been created, it can be attached to the background with the `Environment` module.
 
 ```js
-import {Environment, VideoModule, staticResourceURL} from 'react-360';
+import {Environment, VideoModule, staticAssetURL} from 'react-360';
 
 // Create a player
 const player = VideoModule.createPlayer('myplayer');
 // Play a specific video
 player.play({
-  source: {url: staticResourceURL('path/to/video.mp4')}, // provide the path to the video
+  source: {url: staticAssetURL('path/to/video.mp4')}, // provide the path to the video
   stereo: '3DTB', // optionally, supply the format of the video
 });
 // Display the background video on the Environment
@@ -191,7 +191,7 @@ The `VideoModule` provides a video player wrapper to support playing video on Re
  - `setMuted(muted: boolean)` - determines whether the video is muted or not
  - `setVolume(volume: number)` - sets the volume of the video, on a scale from 0 to 1
  - `destroy()` - tear down the video and clean up its resources
- - `addEventListener(event: string, listener: VideoEventListener)` - add a listener to listen to video player's events, it will return a subscription for unregister
+ - `addListener(event: string, listener: VideoEventListener)` - add a listener to listen to video player's events, it will return a subscription for unregister
  - `removeSubscription(subscription: EmitterSubscription)` - remove a event listener using the subscription
 
 You can also directly use `VideoModule` Native Module with following methods:
@@ -209,11 +209,11 @@ You can also directly use `VideoModule` Native Module with following methods:
 
 ### Video Events
 
-By calling `addEventListener` you will be able to listening to video events from React side. For example:
+By calling `addListener` you will be able to listening to video events from React side. For example:
 
 ```
 const player = VideoModule.createPlayer('myplayer');
-player.addEventListener('onVideoStatusChanged', (event: VideoStatusEvent) => {
+player.addListener('onVideoStatusChanged', (event: VideoStatusEvent) => {
   if (event.status === 'ready') {
     player.removeSubscription(onVideoLoadedSubscription);
     console.log('Video is ready');
@@ -257,7 +257,7 @@ class VideoTest extends Component {
       <View style={{flex: 1}}>
         <VideoPlayer
           muted={true}
-          source={{url: staticResourceURL('path/to/video.mp4')}}
+          source={{url: staticAssetURL('path/to/video.mp4')}}
           stereo={'2D'}
           style={{
             width: 600,

--- a/docs/static-assets.md
+++ b/docs/static-assets.md
@@ -18,7 +18,7 @@ To create references to assets that can be moved at production time, you should 
 <Image source={asset('myImage.png')} />
 ```
 
-The `asset()` method creates a resource object containing a URI path. There may be times where you need to just generate a string path to a resource. You can use `staticResourceURL()` in those situations – it takes a local resource path, and transforms it when your static resources move.
+The `asset()` method creates a resource object containing a URI path. There may be times where you need to just generate a string path to a resource. You can use `staticAssetURL()` in those situations – it takes a local resource path, and transforms it when your static resources move.
 
 ## Specifying the Asset Location
 


### PR DESCRIPTION
Change 'staticResourceURL' to 'staticAssetURL' and React 'addEventListener' to 'addListener'. This should address several issues reported by users due to incorrect documentation.

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][3]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][4] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/react-native
[4]: https://github.com/facebook/react-360/blob/master/CONTRIBUTING.md#pull-requests
