### PR TITLE
Solve issue #646 (Text component link missed in side bar)

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -1,0 +1,44 @@
+---
+id: text
+title: Text
+sidebar_label: Text
+---
+
+Text is a React component for displaying strings. It supports nesting, and styling through size, weight, and color. All strings displayed by your app must be wrapped within Text components – you cannot have a string as the direct child of a View.
+
+## Layout
+
+The Text component is special when it comes to layout. Everything inside a Text element uses text layout instead of flexbox layout. This means elements inside Text are no longe rectangles, but instead wrap when they reach the end of a line.
+
+```html
+<Text>
+  <Text>First part and </Text>
+  <Text>second part</Text>
+</Text>
+// Text container: all the text flows as if it was one
+// |First part |
+// |and second |
+// |part       |
+```
+
+As opposed to
+
+```html
+<View>
+  <Text>First part and </Text>
+  <Text>second part</Text>
+</View>
+// View container: each text is its own block
+// |First part |
+// |and        |
+// |second part|
+```
+
+## Props
+
+### `style? Style | Object`
+### color `color`
+### fontSize `number`
+### fontWeight ```'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'```
+### lineHeight `number`
+### textAlign ``` 'auto' | 'left' | 'center' | 'right' | 'justify' ```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -109,6 +109,10 @@
         "title": "Surfaces",
         "sidebar_label": "Surfaces"
       },
+      "text": {
+        "title": "Text",
+        "sidebar_label": "Text"
+      },
       "view": {
         "title": "View",
         "sidebar_label": "View"


### PR DESCRIPTION
Signed-off-by: Matheus Monte <clark.monte1@gmail.com>

## Motivation (required)

Solve issue #646 of missing link in docs to Text component , this is caused by missing text.md file in docs, I re-added and everything running well.


## Test Plan (required)

- Enter in Website folder 
- execute ```yarn`` 
- ```yarn build```
- check docs version generated in /build path and link to Text component will be showed in side bar

