### PR TITLE
Fixed typo on page photos-and-videos

### DIFF
--- a/docs/photos-and-videos.md
+++ b/docs/photos-and-videos.md
@@ -161,7 +161,7 @@ Environment.setScreen(
 );
 ```
 
-You can also combine these techniques to create a video in the runtime, and layer play it from your React application.
+You can also combine these techniques to create a video in the runtime, and later play it from your React application.
 
 ```js
 // in client.js


### PR DESCRIPTION
Fixed a typo on the documentation page photos-and-videos

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

The PR fixes a typo on photos-and-videos page.

## Test Plan (required)

No code changes here. However, I have run a preview of the file.
The current doc says `You can also combine these techniques to create a video in the runtime, and layer play it from your React application.`  where it should be `You can also combine these techniques to create a video in the runtime, and later play it from your React application.`
